### PR TITLE
Moving the v1.0 release date due to various holidays

### DIFF
--- a/releases/v1.0/schedule.md
+++ b/releases/v1.0/schedule.md
@@ -16,4 +16,4 @@
 |  2023-06-13 | Feature Freeze     | Branch release-1.0             |                                  |                    |
 |  2023-06-20 | RC 0               | Tag v1.0.0-rc.0 on release-1.0 |                                  |                    |
 |  2023-06-27 | RC 1               | Tag v1.0.0-rc.1 on release-1.0 |                                  |                    |
-|  2023-07-04 | GA                 | Tag v1.0.0 on release-1.0      |                                  |                    |
+|  2023-07-11 | GA                 | Tag v1.0.0 on release-1.0      |                                  |                    |


### PR DESCRIPTION
The original date was moved due to a bug in k8s that affected our build but the updated GA date of July 4th is problematic for our US colleagues, and this week has other international holidays that make it somewhat complicated.

In light of this, after discussing it with the maintainers, I propose we move it back one week to July 11th to ensure we have sufficient time to prepare this release and the relevant announcements. I recognise that this is last-minute and I regret any inconvenience to those in the community.

This is following on from and replacing #7  which I believe was closed due to misunderstanding. 
