### PR TITLE
Moving upcoming release dates to align with kubecon

### DIFF
--- a/releases/v1.1/schedule.md
+++ b/releases/v1.1/schedule.md
@@ -12,7 +12,7 @@
 |  2023-09-12   |                    |                                | CI lanes for provider are voting |                    |
 |  2023-09-19   | Beta 0 (1.1)       | Tag v1.1.0-beta.0              |                                  |                    |
 | **October**   |                    |                                |                                  |                    |
-|  2023-10-10   | Feature Freeze     | Branch release-1.1             |                                  |                    |              
-|  2023-10-17   | RC 0               | Tag v1.1.0-rc.0 on release-1.1 |                                  |                    |
-|  2023-10-24   | RC 1               | Tag v1.1.0-rc.1 on release-1.1 |                                  |                    |
-|  2023-10-31   | GA                 | Tag v1.1.0 on release-1.1      |                                  |                    |
+|  2023-10-17   | Feature Freeze     | Branch release-1.1             |                                  |                    |              
+|  2023-10-24   | RC 0               | Tag v1.1.0-rc.0 on release-1.1 |                                  |                    |
+|  2023-10-31   | RC 1               | Tag v1.1.0-rc.1 on release-1.1 |                                  |                    |
+|  2023-11-07   | GA                 | Tag v1.1.0 on release-1.1      |                                  |                    |


### PR DESCRIPTION
Moving upcoming release dates to coincide with KubeCon and benefit from some additional project publicity.
This also gives us a bit of extra time to perform CI maintenance, and for feature reviews. 

