### PR TITLE
Update v1.2 release

### DIFF
--- a/releases/v1.2/schedule.md
+++ b/releases/v1.2/schedule.md
@@ -6,13 +6,13 @@
 | 2023-11-16   |                    |                                |                                  | 1.29.0-beta.0  |
 | 2023-11-23   |                    |                                | Start the 1.29 provider          |                |
 | **December** |                    |                                |                                  |                |
-| 2023-12-05   | Kubernetes Release |                                |                                  | 1.29.0 release |
-| 2023-12-12   | Alpha 0 (1.2)      | Tag v1.2.0-alpha.0             |                                  |                |
+| 2023-12-13   | Kubernetes Release |                                |                                  | 1.29.0 release |
+| 2023-12-20   | Alpha 0 (1.2)      | Tag v1.2.0-alpha.0             |                                  |                |
 | **January**  |                    |                                |                                  |                |
-| 2024-01-09   |                    |                                | CI lanes for provider are voting |                |
-| 2024-01-16   | Beta 0 (1.2)       | Tag v1.2.0-beta.0              |                                  |                |
-| 2024-01-30   | Feature Freeze     | Branch release-1.2             |                                  |                |              
+| 2024-01-16   |                    |                                | CI lanes for provider are voting |                |
+| 2024-01-23   | Beta 0 (1.2)       | Tag v1.2.0-beta.0              |                                  |                |
 | **February** |                    |                                |                                  |                |
-| 2024-02-06   | RC 0               | Tag v1.2.0-rc.0 on release-1.2 |                                  |                |
-| 2024-02-13   | RC 1               | Tag v1.2.0-rc.1 on release-1.2 |                                  |                |
-| 2024-02-20   | GA                 | Tag v1.2.0 on release-1.2      |                                  |                |
+| 2024-02-06   | Feature Freeze     | Branch release-1.2             |                                  |                |
+| 2024-02-13   | RC 0               | Tag v1.2.0-rc.0 on release-1.2 |                                  |                |
+| 2024-02-20   | RC 1               | Tag v1.2.0-rc.1 on release-1.2 |                                  |                |
+| 2024-02-27   | GA                 | Tag v1.2.0 on release-1.2      |                                  |                |


### PR DESCRIPTION
Since kubernetes 1.29 GA date was delayed until Dec 13, we should delay our schedule too.

/cc @aburdenthehand @stu-gott @rthallisey @fabiand @xpivarc 