### PR TITLE
Delay v1.2 by 1 week

### DIFF
--- a/releases/v1.2/schedule.md
+++ b/releases/v1.2/schedule.md
@@ -15,4 +15,4 @@
 | 2024-02-06   | Feature Freeze     | Branch release-1.2             |                                  |                |
 | 2024-02-13   | RC 0               | Tag v1.2.0-rc.0 on release-1.2 |                                  |                |
 | 2024-02-20   | RC 1               | Tag v1.2.0-rc.1 on release-1.2 |                                  |                |
-| 2024-02-27   | GA                 | Tag v1.2.0 on release-1.2      |                                  |                |
+| 2024-03-05   | GA                 | Tag v1.2.0 on release-1.2      |                                  |                |


### PR DESCRIPTION
Let's delay release v1.2 by 1 week as we had a blocker[1] that delayed https://github.com/kubevirt/kubevirt/releases/tag/v1.2.0-rc.1.
This will give us a bit more time to stabilize the release branch.

1. https://github.com/kubevirt/kubevirt/issues/11308