### PR TITLE
Adding Antonio, Federico, Lubo to and alphabetising OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,12 +1,20 @@
 aliases:
   sig-release-approvers:
-  - dhiller
+  - aburdenthehand
+  - acardace
   - davidvossel
-  - rthallisey
+  - dhiller
   - fabiand
+  - fossedihelm
+  - rthallisey
+  - xpivarc
+
   - aburdenthehand
   sig-release-reviewers:
-  - dhiller
-  - rthallisey
-  - fabiand
   - aburdenthehand
+  - acardace
+  - dhiller
+  - fabiand
+  - fossedihelm
+  - rthallisey
+  - xpivarc


### PR DESCRIPTION

Adding Antonio, Federico, and Lubo to the sig-release owners file as they have been responsible for the previous 3 releases and a a critical part of SIG-release.
This PR also alphabetises the file.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
