### PR TITLE
Adding a ROADMAP page that links to our VEP tracking board and upcoming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ KubeVirt SIG release is responsible for scheduling and release KubeVirt.
 
 KubeVirt releases 3 times per year, approximately 8-10 weeks after Kubernetes.
 
+## KubeVirt roadmap
+
+See what's coming in our next release, the features that the KubeVirt community is discussing and prioritising for upcoming releases, and track the lifecycle of features across releases.
+
+The [KubeVirt roadmap](ROADMAP.md) includes links to our Virtualization Enhancements Proposals (VEPs) tracking board and our pre-release notes for our upcoming releases.
+
+## KubeVirt support matrix
+
+Use the [KubeVirt to Kubernetes version support matrix](https://github.com/kubevirt/sig-release/blob/main/releases/k8s-support-matrix.md) to verify the version of KubeVirt that are built and supported for your verstion of Kubernetes.
+
 ## To start using KubeVirt
 
 Try our quickstart at [kubevirt.io](http://kubevirt.io/get_kubevirt/).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,5 +8,5 @@ You can view the current [KubeVirt Enhancements Tracking board](https://github.c
 
 When a VEP is prioritised for the next release, the KubeVirt community is signifying that the owning SIG will ensure there is support for reviewing and the shepherding of the feature for the assigned release. There is still the possibility that the author will not complete the feature PR before code freeze or other unexpected circumstances could delay the feature.
 
-For a list of PRs that have been merged and can be expected in the next release, please see our list of [noteworthy changes for the next KubeVirt release](https://github.com/kubevirt/sig-release/blob/main/upcoming-changes.md) page. These can be considered our 'pre-release notes' and is updated daily.
+For a list of PRs that have been merged and can be expected in the next release, please see our list of [noteworthy changes for the next KubeVirt release](https://github.com/kubevirt/sig-release/blob/main/upcoming-changes.md) page. These can be considered our 'pre-release notes' and are updated daily.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,12 @@
+---
+title: KubeVirt Roadmap
+---
+
+KubeVirt has implemented [Virtualization Enhancement Proposals (VEPs)](https://github.com/kubevirt/enhancements) in order to agree upon implementation details of large feature work and track the feature lifecycle.
+
+You can view the current [KubeVirt Enhancements Tracking board](https://github.com/orgs/kubevirt/projects/15) to get an idea on the list of currently open VEPs, their state, and whether they have been prioritised by the community for the next release. You are also welcome and encouraged to add to the discussion on these proposals, and to express support for VEPs that you would like to see prioritised.
+
+When a VEP is prioritised for the next release, the KubeVirt community is signifying that the owning SIG will ensure there is support for reviewing and the shepherding of the feature for the assigned release. There is still the possibility that the author will not complete the feature PR before code freeze or other unexpected circumstances could delay the feature.
+
+For a list of PRs that have been merged and can be expected in the next release, please see our list of [noteworthy changes for the next KubeVirt release](https://github.com/kubevirt/sig-release/blob/main/upcoming-changes.md) page. These can be considered our 'pre-release notes' and is updated daily.
+


### PR DESCRIPTION
Adding a ROADMAP page that links to our VEP tracking board and our pre-release notes. 
The link to the tracking board will need to be updated with each release... hopefully that can be automated?

This PR also adds in sections on our README that link to the new roadmap page and the support matrix to improve visibility.

**Special notes for your reviewer**:
I included light detail into the process but prefer a high view just to provide some context and set expectations about what these mean; I'd rather link to and leave the details in the enhancements repo so there's one place to update. Let me know if you think any of this should be expanded upon. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding roadmap document
```
