### PR TITLE
[v1.6] Postpone

### DIFF
--- a/releases/v1.6/schedule.md
+++ b/releases/v1.6/schedule.md
@@ -16,8 +16,8 @@
 | **June**   |                        |             |                                  |                                                                                                                                         |
 | 2025/06/25 | KubeVirt Code Freeze   | KubeVirt    | Branch release-1.6               | Review [list of quarantined tests](https://storage.googleapis.com/kubevirt-prow/reports/quarantined-tests/kubevirt/kubevirt/index.html) |
 | **July**   |                        |             |                                  |                                                                                                                                         |
-| 2025/07/09 | KubeVirt RC 0          | KubeVirt    | Tag v1.6.0-rc.0 on release-1.6   |                                                                                                                                         |
-| 2025/07/16 | KubeVirt RC 1          | KubeVirt    | Tag v1.6.0-rc.1 on release-1.6   |                                                                                                                                         |
-| 2025/07/24 | **KubeVirt GA**        | KubeVirt    | Tag v1.6.0 on release-1.6        |                                                                                                                                         |
+| 2025/07/18 | KubeVirt RC 0          | KubeVirt    | Tag v1.6.0-rc.0 on release-1.6   |                                                                                                                                         |
+| 2025/07/25 | KubeVirt RC 1          | KubeVirt    | Tag v1.6.0-rc.1 on release-1.6   |                                                                                                                                         |
+| 2025/07/30 | **KubeVirt GA**        | KubeVirt    | Tag v1.6.0 on release-1.6        |                                                                                                                                         |
 | 2025/07/31 | **CDI GA**             | CDI         | v1.63.0 release                  | [CDI](https://github.com/kubevirt/containerized-data-importer) aims to release approximately a week following KubeVirt                  |
 


### PR DESCRIPTION
Numerous issues made it impossible to cut rc.0 on time, therefore reflecting it into schedule. Unfortunately the instance types update missed the rc.0 and therefore we are going to cut second planed rc.1. It is note worthy that there are couple of bugs fixed since rc.0 as well.
