### PR TITLE
release-checklist: Add post-CDI GA task to pin release branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-tracker.md
+++ b/.github/ISSUE_TEMPLATE/release-tracker.md
@@ -85,6 +85,7 @@ The issue should be kept open for the entirety of the release cycle until all ta
 
 - [ ] Update KubeVirt Enhancements Tracking board link in [ROADMAP](https://github.com/kubevirt/sig-release/blob/main/ROADMAP.md).
 - [ ] Update [label-approved-veps script](https://github.com/kubevirt/kubevirt/blob/main/.github/workflows/label_approved_veps.yaml) with the new `TARGET_PROJECT_URL`.
+- [ ] After CDI GA: Pin release-1.XX branch to associated CDI version via `KUBEVIRT_CUSTOM_CDI_VERSION` in `automation/test.sh`.
 
 ## Further comments
 

--- a/releases/release-checklist.md
+++ b/releases/release-checklist.md
@@ -20,3 +20,4 @@ A KubeVirt release entails a variety of tasks to complete in concert with the re
 | GA                                | Email to mailing list                                        | SIG-release                                |
 |                                   | Publish/unhold release notes and blog                        | Docs and Community                         |
 |                                   | Promote through social media                                 | Community                                  |
+| After CDI GA                      | Pin release branch to associated CDI version                 | SIG-release                                |


### PR DESCRIPTION
## Summary
- Adds a new "After CDI GA" row to the release checklist for pinning the KubeVirt release branch to its associated CDI version
- This is done by exporting `KUBEVIRT_CUSTOM_CDI_VERSION` in `automation/test.sh` since `KUBEVIRTCI_TAG` cannot be bumped after a release

## Context
- kubevirt/kubevirt#16472
- kubevirt/kubevirt#16474 (release-1.7 → CDI v1.64.0)
- kubevirt/kubevirt#16478 (release-1.6 → CDI v1.63.1)
- kubevirt/kubevirt#17372 (release-1.8 → CDI v1.65.0)